### PR TITLE
行がフィルタリングされた際の色範囲の更新

### DIFF
--- a/src/qp.py
+++ b/src/qp.py
@@ -119,12 +119,9 @@ class GpmlD3Visualizer:
                 selected_expression_data = self.expression_data.filter(pl.col('xref_id').is_in(gids))
             else:
                 selected_expression_data = self.expression_data                
-
-            if selected_expression_data.shape[0] == 0:
-                print("No expression data found")
-                return
             self.selected_expression_data = selected_expression_data
-            self.heatmap_widget.selected_gene_ids = gids
+            self.heatmap_widget.selected_gene_ids = original_gids
+
 
         self.visualizer_widget.observe(on_gene_ids_change, names='value')
         

--- a/src/templates/pathway_d3_view_widget.js
+++ b/src/templates/pathway_d3_view_widget.js
@@ -255,7 +255,6 @@ define("pathway_d3_view_widget", ["@jupyter-widgets/base", "d3"], function (
     function calculateWayPoints(connectionPoints) {
       let wayPoints = [];
       const SEGMENT_OFFSET = 20; // 中継点のオフセット
-      console.log(connectionPoints);
       let previousHorizontal = false;
       for (let i = 0; i < connectionPoints.length - 1; i++) {
         let point1 = connectionPoints[i];
@@ -362,7 +361,6 @@ define("pathway_d3_view_widget", ["@jupyter-widgets/base", "d3"], function (
       .each(function (d) {
         if (d.Graphics?.ConnectorType === "Elbow") {
           let wayPoints = calculateWayPoints(d.points);
-          console.log({ wayPoints });
           for (let i = 0; i < wayPoints.length - 1; i++) {
             drawLine(
               d3.select(this),


### PR DESCRIPTION
遺伝子の選択状態が変わった際に、選択された遺伝子だけで改めてヒートマップの色範囲を計算するようにしました。
（加えて、何もxref_idが紐づいていないノードを選択したときの挙動が変で、すべての行が表示される形になってしまっていたので合わせて修正しました）