### PR TITLE
fix: Add labextension build artifacts to docker-compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
     volumes:
       - ".:/home/jovyan/work"
       - "/home/jovyan/work/qpx_widgets/node_modules" # node_modulesを匿名ボリュームで除外
+      - "/home/jovyan/work/qpx_widgets/qpx_widgets/labextension" # labextensionのビルド成果物も匿名ボリュームで除外


### PR DESCRIPTION
docker-composeでの起動時にJupyterLab拡張が見つからない不具合を修正しました。